### PR TITLE
Add ability to truncate %CONTENT% similar to %DESCRIPTION%

### DIFF
--- a/lib/parser.php
+++ b/lib/parser.php
@@ -71,7 +71,24 @@ function parse( $template, $values, $feed ) {
 	    },
 	 	$template
 	 );
-	
+
+    // truncated content
+    $template = preg_replace_callback(
+        '/%CONTENT\|(\d+)%/',
+        function ( $matches ) use ( $values ) {
+                    $stripped = strip_tags( $values[ 'content' ] );
+                    $short = implode( ' ', array_slice( explode( ' ', $stripped ), 0, $matches[1] ) );
+
+                    $ellipsis = '';
+                    if ( $short != $stripped )
+                            $ellipsis = ' ...';
+
+
+            return $short . $ellipsis;
+        },
+            $template
+     );
+
 	// custom date format
 	$template = preg_replace_callback(
 	    '/%DATE\|(.+)%/',


### PR DESCRIPTION
I wanted to syndicate blog posts but cut it off after 400-500 words. I don't know much about PHP, but I got this to work by copy-pasting a block of code and replacing the word 'description' with 'content' :)
