### PR TITLE
add optional support for WP shortcodes in templates

### DIFF
--- a/lib/models/feed_collection.php
+++ b/lib/models/feed_collection.php
@@ -51,6 +51,9 @@ class FeedCollection extends Base
 FeedCollection::property( 'id', 'INT NOT NULL AUTO_INCREMENT PRIMARY KEY' );
 FeedCollection::property( 'name', 'VARCHAR(255)' );
 FeedCollection::property( 'before_template', 'TEXT' );
+FeedCollection::property( 'before_template_shortcodes', 'TINYINT' );
 FeedCollection::property( 'body_template', 'TEXT' );
+FeedCollection::property( 'body_template_shortcodes', 'TINYINT' );
 FeedCollection::property( 'after_template', 'TEXT' );
+FeedCollection::property( 'after_template_shortcodes', 'TINYINT' );
 // FeedCollection::has_many( 'MultiFeedReader\Models\Feed', array( 'plural' => 'feeds' ) );

--- a/mfrsettings.php
+++ b/mfrsettings.php
@@ -399,6 +399,14 @@ function display_edit_page() {
 						</th>
 						<td>
 							<textarea name="feedcollection[before_template]" rows="10" class="large-text"><?php echo $current->before_template ?></textarea>
+							<br />
+							<fieldset>
+								<legend><?php echo __( 'WP shortcodes', 'multi-feed-reader' ) ?>:</legend>
+								<input type="radio" name="feedcollection[before_template_shortcodes]" value="1" id="before_template_shortcodes_enable"<?= $current->before_template_shortcodes == '1' ? ' checked="checked"' : '' ?> />
+								<label for="before_template_shortcodes_enable"><?php echo __( 'enabled', 'multi-feed-reader' ) ?></label>
+								<input type="radio" name="feedcollection[before_template_shortcodes]" value="0" id="before_template_shortcodes_disable"<?= $current->before_template_shortcodes != '1' ? ' checked="checked"' : '' ?> />
+								<label for="before_template_shortcodes_disable"><?php echo __( 'disabled', 'multi-feed-reader' ) ?></label>
+							</fieldset>
 						</td>
 					</tr>
 					<tr valign="top">
@@ -407,6 +415,14 @@ function display_edit_page() {
 						</th>
 						<td>
 							<textarea name="feedcollection[body_template]" rows="10" class="large-text"><?php echo $current->body_template ?></textarea>
+							<br />
+							<fieldset>
+								<legend><?php echo __( 'WP shortcodes', 'multi-feed-reader' ) ?>:</legend>
+								<input type="radio" name="feedcollection[body_template_shortcodes]" value="1" id="body_template_shortcodes_enable"<?= $current->body_template_shortcodes == '1' ? ' checked="checked"' : '' ?> />
+								<label for="body_template_shortcodes_enable"><?php echo __( 'enabled', 'multi-feed-reader' ) ?></label>
+								<input type="radio" name="feedcollection[body_template_shortcodes]" value="0" id="body_template_shortcodes_disable"<?= $current->body_template_shortcodes != '1' ? ' checked="checked"' : '' ?> />
+								<label for="body_template_shortcodes_disable"><?php echo __( 'disabled', 'multi-feed-reader' ) ?></label>
+							</fieldset>
 						</td>
 					</tr>
 					<tr valign="top">
@@ -415,6 +431,14 @@ function display_edit_page() {
 						</th>
 						<td>
 							<textarea name="feedcollection[after_template]" rows="10" class="large-text"><?php echo $current->after_template ?></textarea>
+							<br />
+							<fieldset>
+								<legend><?php echo __( 'WP shortcodes', 'multi-feed-reader' ) ?>:</legend>
+								<input type="radio" name="feedcollection[after_template_shortcodes]" value="1" id="after_template_shortcodes_enable"<?= $current->after_template_shortcodes == '1' ? ' checked="checked"' : '' ?> />
+								<label for="after_template_shortcodes_enable"><?php echo __( 'enabled', 'multi-feed-reader' ) ?></label>
+								<input type="radio" name="feedcollection[after_template_shortcodes]" value="0" id="after_template_shortcodes_disable"<?= $current->after_template_shortcodes != '1' ? ' checked="checked"' : '' ?> />
+								<label for="after_template_shortcodes_disable"><?php echo __( 'disabled', 'multi-feed-reader' ) ?></label>
+							</fieldset>
 						</td>
 					</tr>
 				</tbody>

--- a/plugin.php
+++ b/plugin.php
@@ -97,10 +97,22 @@ function generate_html_by_template( $template, $limit ) {
 	
 	$timer->start( 'render' );
 	$out = $collection->before_template;
-	foreach ( $feed_items as $item ) {
-		$out .= Parser\parse( $collection->body_template, $item, $feed_data[ $item[ 'feed_id' ] ] );
+	if ($collection->before_template_shortcodes == '1') {
+		$out = do_shortcode($out);
 	}
-	$out .= $collection->after_template;
+	foreach ( $feed_items as $item ) {
+		$body_template = $collection->body_template;
+		if ($collection->body_template_shortcodes == '1') {
+			$body_template = do_shortcode($body_template);
+		}
+		$out .= Parser\parse( $body_template, $item, $feed_data[ $item[ 'feed_id' ] ] );
+	}
+	$after_template = $collection->after_template;
+	if ($collection->after_template_shortcodes == '1') {
+		$after_template = do_shortcode($after_template);
+	}
+	$out .= $after_template;
+
 	$timer->stop( 'render' );
 
 	write_log(


### PR DESCRIPTION
Thank you @eteubert for building this great plugin.
I'm using it to generate podcast player on my website in the widget area.

This PR adds optional support for WP shortcodes in `before`, `body` and `after` templates.
Thanks to this you can use (for instance) an external plugin to generate audio player for embeded files.

Additional columns in `wp_multifeedreader_feedcollection` table are required: 

`before_template_shortcodes` TINYINT(1)
`body_template_shortcodes` TINYINT(1)
`after_template_shortcodes` TINYINT(1)

Part of the administration panel in action:

![shortcodes](https://cloud.githubusercontent.com/assets/3033038/17703283/6af5bcd4-63d1-11e6-94e6-19c8ef1f038d.png)
