### PR TITLE
add support for WP shortcodes in templates

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -103,6 +103,8 @@ function generate_html_by_template( $template, $limit ) {
 	$out .= $collection->after_template;
 	$timer->stop( 'render' );
 
+	$out = do_shortcode($out);
+
 	write_log(
 		sprintf(
 			'template generated. fetch: %ss, parse: %ss, sort: %ss, render: %ss',


### PR DESCRIPTION
This PR adds support for WP shortcodes in `before`, `body` and `after` templates.

Originally proposed in https://github.com/eteubert/multi-feed-reader/pull/8